### PR TITLE
Working build

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -8,9 +8,16 @@ cp -r "$ekamSrc" ekam
 chmod -R u+w ekam
 cd ekam
 mkdir -p deps
+# A single capnproto test file expects to be able to write to
+# /var/tmp.  We change it to use /tmp because /var is not available
+# under nix-build.
 cp -r "$capnprotoSrc" deps/capnproto
 chmod u+w deps/capnproto/c++/src/kj -R
 sed -i 's/\/var\/tmp/\/tmp/g' deps/capnproto/c++/src/kj/filesystem-disk-test.c++
+# Turn off the purity check because it doesn't fare well with ekam.
+# This is also done in a handful of other expressions in nixpkgs.  See
+# discussion at https://github.com/NixOS/nixpkgs/issues/13532 and at
+# https://github.com/zenhack/ekam-nix/pull/4
 unset NIX_ENFORCE_PURITY
 make
 mkdir $out

--- a/builder.sh
+++ b/builder.sh
@@ -8,5 +8,10 @@ cp -r "$ekamSrc" ekam
 chmod -R u+w ekam
 cd ekam
 mkdir -p deps
-ln -s "$capnprotoSrc" deps/capnproto
+cp -r "$capnprotoSrc" deps/capnproto
+chmod u+w deps/capnproto/c++/src/kj -R
+sed -i 's/\/var\/tmp/\/tmp/g' deps/capnproto/c++/src/kj/filesystem-disk-test.c++
+unset NIX_ENFORCE_PURITY
 make
+mkdir $out
+cp -r bin $out


### PR DESCRIPTION
- The line `unset NIX_ENFORCE_PURITY` is, of course, reminiscent of https://github.com/NixOS/nixpkgs/issues/13532.
- Some test failures remained because there is no `/var` (and thus no `/var/tmp`) in the build environment.  So I used `sed` to patch the capnproto sources in place.

This is probably not the final solution, but it at least works!